### PR TITLE
Fixed typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 - 👋 Hi, I’m @raymond1
 - 👀 I’m interested in meeting people.
-- 🌱 I’m currently learning random front end things related to JavaScript.
-- 💞️ I’m looking not looking to collaborate.
+- 🌱 I’m currently learning random front-end things related to JavaScript.
+- 💞️ I’m not looking to collaborate.
 - 📫 You can reach me by email at raymondleon@raymondleon.ca.
 


### PR DESCRIPTION
`front-end` should be used as an adjective, while `front end` should be used as a noun
Also, `looking not looking` makes no sense